### PR TITLE
Add UserRepository for ApplicationUser CRUD operations

### DIFF
--- a/Hairdresser/Program.cs
+++ b/Hairdresser/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddIdentity<IdentityUser, IdentityRole>()
 //Repositories
 builder.Services.AddScoped<IGenericRepository<Treatment>, TreatmentRepository>();
 builder.Services.AddScoped<IGenericRepository<Booking>, BookingRepository>();
+builder.Services.AddScoped<IGenericRepository<ApplicationUser>, UserRepository>();
 
 //Services
 

--- a/Hairdresser/Repositories/UserRepository.cs
+++ b/Hairdresser/Repositories/UserRepository.cs
@@ -1,0 +1,49 @@
+﻿using Hairdresser.Data;
+using Hairdresser.Repositories.Interfaces;
+using HairdresserClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+
+namespace Hairdresser.Repositories
+{
+	public class UserRepository :IGenericRepository<ApplicationUser>
+	{
+		private readonly ApplicationDBContext _context;
+		public UserRepository(ApplicationDBContext context)
+		{
+			_context = context;
+		}
+		public async Task AddAsync(ApplicationUser entity)
+		{
+			await _context.ApplicationUsers.AddAsync(entity);
+			await _context.SaveChangesAsync();
+		}
+
+		public async Task DeleteAsync(ApplicationUser entity)
+		{
+			_context.ApplicationUsers.Remove(entity);
+			await _context.SaveChangesAsync();
+		}
+
+		public async Task<IEnumerable<ApplicationUser>> FindAsync(Expression<Func<ApplicationUser, bool>> predicate)
+		{
+			return await _context.ApplicationUsers.Where(predicate).ToListAsync();
+		}
+
+		public async Task<IEnumerable<ApplicationUser>> GetAllAsync()
+		{
+			return await _context.ApplicationUsers.ToListAsync();
+		}
+
+		public async Task<ApplicationUser?> GetByIdAsync(int id)
+		{
+			return await _context.ApplicationUsers.FindAsync(id);
+		}
+
+		public async Task UpdateAsync(ApplicationUser entity)
+		{
+			_context.ApplicationUsers.Update(entity);
+			await _context.SaveChangesAsync();
+		}
+	}
+}


### PR DESCRIPTION
Introduced a new `UserRepository` class implementing the `IGenericRepository<ApplicationUser>` interface to handle CRUD operations for `ApplicationUser` using Entity Framework Core.

Registered `UserRepository` in `Program.cs` for dependency injection, ensuring it is available wherever an
`IGenericRepository<ApplicationUser>` is required.

Added necessary `using` directives to `UserRepository.cs` for namespace imports.