### PR TITLE
Fix nullable warnings in UserManager instantiation

### DIFF
--- a/HairdresserUnitTests/UsersControllerTests.cs
+++ b/HairdresserUnitTests/UsersControllerTests.cs
@@ -24,7 +24,7 @@ namespace HairdresserUnitTests
 
             var userStore = new Mock<IUserStore<ApplicationUser>>();
             var userManager = new UserManager<ApplicationUser>(
-                userStore.Object, null, null, null, null, null, null, null, null
+                userStore.Object, null!, null!, null!, null!, null!, null!, null!, null!
             );
 
             return new UsersController(context, userManager);


### PR DESCRIPTION
Replaced `null` with `null!` in `UserManager<ApplicationUser>` constructor within `UsersControllerTests.cs` under the `HairdresserUnitTests` namespace. This suppresses nullable reference type warnings, ensuring compatibility with the project's nullable reference type settings.