### PR TITLE
Remove `FileName` class and `Hairdresser.Services` namespace

### DIFF
--- a/Hairdresser/Services/FileName.cs
+++ b/Hairdresser/Services/FileName.cs
@@ -1,6 +1,0 @@
-﻿namespace Hairdresser.Services
-{
-	public class FileName
-	{
-	}
-}


### PR DESCRIPTION
The `FileName` class was entirely removed, including its opening and closing braces. Additionally, the `Hairdresser.Services` namespace declaration was deleted as part of this change.