### PR TITLE
Add new test and update existing test in BookingControllerTests

### DIFF
--- a/HairdresserUnitTests/BookingControllerTests.cs
+++ b/HairdresserUnitTests/BookingControllerTests.cs
@@ -43,7 +43,7 @@ namespace HairdresserUnitTests
 		public async Task BookAppointment_ReturnsOkWithCorrectBookingData()
 		{
 			// Arrange
-			var treatment = new Treatment { Id = 1, Duration = 30 };
+			var treatment = new Treatment { Id = 2, Duration = 30 };
 			var bookingDTO = new BookingRequestDto
 			{
 				Start = DateTime.Now.AddDays(2),
@@ -69,6 +69,7 @@ namespace HairdresserUnitTests
 			{
 				Assert.Fail("Unexpected result type: " + result.GetType().Name);
 			}
+			Cleanup();
 		}
 
 		[TestMethod]


### PR DESCRIPTION
The `BookAppointment_ReturnsOkWithCorrectBookingData` test was updated:
- The `Id` of the `Treatment` object was changed from `1` to `2`.
- A call to the new `Cleanup()` method was added at the end of the test.

A new test method `Book_NonExisting_Treatment_Returns404` was added to verify behavior when booking a non-existing treatment.