### PR TITLE
Return treatment object in success response

### DIFF
--- a/Hairdresser/Controllers/TreatmentController.cs
+++ b/Hairdresser/Controllers/TreatmentController.cs
@@ -60,7 +60,7 @@ namespace Hairdresser.Controllers
                 return NotFound();
             }
 
-            return Ok();
+            return Ok(treatment);
         }
 
         [HttpDelete("{id}")]


### PR DESCRIPTION
Updated the `TreatmentController` to return `Ok(treatment)` instead of a generic `Ok()` in the success response of a method (likely HTTP PUT/POST). This change provides more detailed feedback to the client about the operation's result.